### PR TITLE
Add measurement of execution duration

### DIFF
--- a/watts-plugin-tester.go
+++ b/watts-plugin-tester.go
@@ -280,6 +280,7 @@ func (pluginInput *PluginInput) doPluginTest(pluginName string) (output Output) 
 	pluginOutput, err := exec.Command(pluginName, inputBase64).CombinedOutput()
 	if err != nil {
 		output.print("result", "error")
+		output.print("error", fmt.Sprint(err))
 		output.print("description", "error executing the plugin")
 		return
 	}

--- a/watts-plugin-tester.go
+++ b/watts-plugin-tester.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"time"
 )
 
 type PluginInput map[string](*json.RawMessage)
@@ -277,7 +278,10 @@ func (pluginInput *PluginInput) doPluginTest(pluginName string) (output Output) 
 
 	inputBase64 := base64.StdEncoding.EncodeToString(pluginInputJson)
 
+	timeBeforeExec := time.Now()
 	pluginOutput, err := exec.Command(pluginName, inputBase64).CombinedOutput()
+	timeAfterExec := time.Now()
+	execDuration := timeAfterExec.Sub(timeBeforeExec)
 	if err != nil {
 		output.print("result", "error")
 		output.print("error", fmt.Sprint(err))
@@ -308,6 +312,8 @@ func (pluginInput *PluginInput) doPluginTest(pluginName string) (output Output) 
 		output.print("description", "error processing the output of the plugin (into an interface)")
 		return
 	}
+
+	output.print("time", fmt.Sprint(execDuration))
 
 	path, errr := wattsSchemes[wattsVersion][*pluginTestAction].Validate(pluginOutputInterface)
 	if errr != nil {


### PR DESCRIPTION
 `./watts-plugin-tester test ../tts_plugin_info/plugin/info.py` gives for example
```
plugin_name: ../tts_plugin_info/plugin/info.py
         action: parameter
          input: {...}
   end of input

         output: {...}
  end of output

           time: 30.270481ms
         result: ok
    description: validation passed
```

Also, add printing of error details when `exec.Command` fails.

Resolves #5 